### PR TITLE
[Fix] - About 페이지 누락된 팀 추가

### DIFF
--- a/apps/web/app/about/constants/committeeSection.ts
+++ b/apps/web/app/about/constants/committeeSection.ts
@@ -65,4 +65,9 @@ export const TEAMS: Team[] = [
     leader: "정예원",
     members: ["윤희경", "정선영"],
   },
+  {
+    name: "회계팀",
+    leader: "유용준",
+    members: ["정영준"],
+  },
 ];


### PR DESCRIPTION
# 🔥 Pull requests

## 💻 작업 내용

- about 페이지의 졸업준비위원회에 누락된 회계팀을 추가했습니다.