### PR TITLE
feat(seo): JSON-LD 구조화 데이터 추가 및 작품 페이지 메타데이터 강화

### DIFF
--- a/apps/web/app/about/page.tsx
+++ b/apps/web/app/about/page.tsx
@@ -16,6 +16,7 @@ import {
   EVENT_TITLE,
   ROPE_FRAME_CONFIG,
 } from "./constants";
+import JsonLd from "@components/JsonLd";
 
 export const metadata: Metadata = {
   title: "ABOUT",
@@ -35,9 +36,40 @@ export const metadata: Metadata = {
   },
 };
 
+const siteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://2025.snudesignweek.com";
+
+const exhibitionJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "ExhibitionEvent",
+  name: "SNU DESIGN WEEK 2025 | WRAP UP",
+  description: "서울대학교 디자인학부 졸업전시 2025",
+  startDate: "2025-12-04",
+  endDate: "2025-12-09",
+  eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+  eventStatus: "https://schema.org/EventScheduled",
+  location: {
+    "@type": "Place",
+    name: "서울대학교 49동 & 파워플랜트",
+    address: {
+      "@type": "PostalAddress",
+      addressLocality: "서울",
+      addressCountry: "KR",
+    },
+  },
+  organizer: {
+    "@type": "Organization",
+    name: "서울대학교 디자인학부",
+    url: siteUrl,
+  },
+  image: `${siteUrl}/meta/og-image.png`,
+  url: `${siteUrl}/about`,
+};
+
 export default function About() {
   return (
     <S.Wrapper>
+      <JsonLd data={exhibitionJsonLd} />
       <aside aria-label="전시 포스터">
         <S.PosterContainer>
           <Image

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -5,6 +5,7 @@ import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 import EmotionRegistry from "./emotion-registry";
 import { Header } from "@snud2025/ui";
+import JsonLd from "@components/JsonLd";
 
 const pretendard = localFont({
   src: "./fonts/PretendardVariable.woff2",
@@ -108,6 +109,14 @@ export const metadata: Metadata = {
   },
 };
 
+const websiteJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "SNU DESIGN WEEK 2025",
+  alternateName: "서울대학교 디자인학부 졸업전시 2025",
+  url: siteUrl,
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -116,6 +125,7 @@ export default function RootLayout({
   return (
     <html lang="ko" suppressHydrationWarning>
       <head>
+        <JsonLd data={websiteJsonLd} />
         {/* Typekit 폰트 로딩 최적화 */}
         <link
           rel="preconnect"

--- a/apps/web/components/JsonLd.tsx
+++ b/apps/web/components/JsonLd.tsx
@@ -1,0 +1,12 @@
+interface JsonLdProps {
+  data: Record<string, unknown>;
+}
+
+export default function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- 작가 이름과 작품명 검색 시 Google 노출을 개선하기 위한 SEO 강화

## Changes
- `components/JsonLd.tsx`: 재사용 JSON-LD 스크립트 주입 컴포넌트 추가
- `works/[id]/page.tsx`: title에 작가 이름 앞배치, keywords/canonical URL 추가, VisualArtwork + Person JSON-LD 삽입
- `about/page.tsx`: ExhibitionEvent JSON-LD 구조화 데이터 추가
- `layout.tsx`: WebSite JSON-LD 구조화 데이터 추가

## Test Plan
- [x] `pnpm run check-types` 통과 확인
- [x] `/works/[id]` 페이지 소스에서 `<title>`에 작가 이름 앞배치 확인
- [x] 각 페이지 소스에서 `application/ld+json` 스크립트 존재 확인
- [x] Google Rich Results Test로 구조화 데이터 검증